### PR TITLE
Fixed private method `prepend' called for I18n::Backend::Simple:Class…

### DIFF
--- a/lib/i18n/debug.rb
+++ b/lib/i18n/debug.rb
@@ -39,5 +39,5 @@ module I18n
     end
   end
 
-  Backend::Simple.prepend(Debug::Hook)
+  Backend::Simple.send(:prepend, Debug::Hook)
 end


### PR DESCRIPTION
… (NoMethodError)

on Ruby 2.0 and Rails 4.2
